### PR TITLE
fix: updated InitWindField.py

### DIFF
--- a/pymdu/physics/aeraulic/uRockle/InitWindField.py
+++ b/pymdu/physics/aeraulic/uRockle/InitWindField.py
@@ -3847,7 +3847,7 @@ def setInitialWindField(
             str(i) + ',' + str(j)
             for i, j in buildingHeightWindSpeed.set_index(Z)[
                 HORIZ_WIND_SPEED
-            ].iteritems()
+            ].items()
         ]
         cursor.execute(
             """


### PR DESCRIPTION
On a rencontré un problème lors du run de Urock :
`Error: 'Series' object has no attribute 'iteritems'`

Le fix consiste à remplacer l'attribut iteritems() par items()