### PR TITLE
feature(diffuse): add possibility to only prodive direct radiation

### DIFF
--- a/pymdu/physics/umep/Solweig.py
+++ b/pymdu/physics/umep/Solweig.py
@@ -59,6 +59,7 @@ class Solweig(UmepCore):
         abs_l=0.95,
         posture=0.5,
         cyl=True,
+        only_global=False,
     ):
         if meteo_path is not None:
             self.meteo_path = meteo_path
@@ -109,6 +110,7 @@ class Solweig(UmepCore):
                 'OUTPUT_SH': True,
                 'OUTPUT_TREEPLANTER': False,
                 'OUTPUT_DIR': self.output_dir,
+                'ONLY_GLOBAL': only_global,
             },
         )
 


### PR DESCRIPTION
Actuellement Solweig attend du rayonnement direct et diffus. 
Il est cependant possible de le faire tourner avec juste du rayonnement global mais pour cela il faut ajouter l'option `ONLY_GLOBAL`
Comme il était par défaut définie à False dans Solweig, si on n'ajoute pas cet argument ça ne change rien p/r à avant.